### PR TITLE
Document license status of source sounds

### DIFF
--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -1,5 +1,5 @@
 OpenSFX README
-Last updated:    2010-03-31
+Last updated:    2021-01-25
 Release version: {{REPO_TITLE}}
 ------------------------------------------------------------------------
 
@@ -14,6 +14,11 @@ Table of Contents:
  * 3.1) Compiling the source
  * 3.2) Contributing
 4.0) Credits
+ * 4.1) Sound credits of source sounds
+ * 4.2) Sound editors
+ * 4.3) Other authors
+ * 4.4) License reference
+5.0) Acknowledgements
 
 
 1.0) About OpenSFX
@@ -21,27 +26,49 @@ Table of Contents:
 OpenSFX is a set of base sounds for OpenTTD and is the result of the
 "Sound Effects Replacement" project.
 
-OpenSFX is an open source replacement for the original Transport Tycoon
-Deluxe base sounds used by OpenTTD. The main goal of OpenSFX therefore
+OpenSFX is a replacement for the original Transport Tycoon Deluxe
+base sounds used by OpenTTD. The main goal of OpenSFX therefore
 is to provide a set of free sounds which make it possible to play
 OpenTTD without requiring the (copyrighted) files from the Transport
-Tycoon Deluxe cd. This potentially increases the OpenTTD fanbase and
-makes it a true free game (with "free" as in both "free beer" and "open
-source").
+Tycoon Deluxe CD. This potentially increases the OpenTTD fanbase.
+
+Currently, the OpenSFX sounds are free as as in 'free beer' but
+not as in 'freedom' as OpenSFX is licensed under a legacy license
+that is universally considered to be 'non-free' by the free software
+and open source communities because it is too restrictive.
+We hope to fix that eventually and turn OpenSFX into a sound pack
+that is also 'free as in freedom'.
 
 1.1) License
 ==== =======
 OpenSFX is licensed under the Creative Commons Sampling Plus 1.0 License.
 You can find the full text in license.txt.
 
-This license has been chosen as the majority all of the original samples
-are licensed under the Creative Commons Sampling Plus 1.0 License with
-the exception of a single original sample under public domain. If you
-are interested in this package having a more free license, i.e. a
-license that is deemed free by Debian, Fedora and the other Linux
-distributions, you have to either contact the original authors and ask
-them to relicense them or redo the samples so they can licensed under a
-license that is deemed free.
+1.1.1) Background
+====== ==========
+Note this license is at odds with free software values. For instance,
+it vaguely forbids using the work in "advertisement", which is a major
+restriction. Even the Creative Commons organization discourages it now.
+
+Historically, this license has been chosen as it was believed the
+majority all of the original samples were licensed under the
+Creative Commons Sampling Plus 1.0 License with the exception of a single
+original sample under public domain. However, on further investigation
+it turned out that this assumption was wrong, only a fraction of the
+original samples actually carry this license. But there are still
+a few sounds under that license left.
+Another reason is that the people who did the mixing and sound editing
+agreed on Sampling Plus and that hasn't been changed since.
+And for those reasons, OpenSFX is still stuck with Sampling Plus.
+
+If you are interested in this package having a 'truly' free license, i.e.
+a license that is deemed free by Debian, Fedora and the other Linux
+distributions, you have to either contact the original authors of the
+'non-libre' sounds and ask them to relicense them or redo the samples
+so they can licensed under a license that is deemed free.
+
+If you want to help us, please visit
+<https://github.com/OpenTTD/OpenSFX/>.
 
 2.0) Installing
 ==== ==========
@@ -166,140 +193,198 @@ that allows us to release it under that license.
 
 4.0) Credits
 ==== =======
-The original sources of our mixed samples are:
- - "1sticky8" from "freesound.org"
-    * Dumpster_Diving.wav
- - "acclivity" from "freesound.org"
-    * ChugChugWooHoo.mp3
-    * TwoCows.wav
- - "AGFX" from "freesound.org"
-    * Squeeky ball Toy_1.L.wav
- - "Aldor" from "pdsounds.org"
-    * L'ascenseur - Elevator
- - "alexrigg" from "freesound.org"
-    * crash_treefall_SE.mp3
- - "Anton" from "freesound.org"
-    * wind1.wav
- - "Benboncan" from "freesound.org"
-    * Circular saw crosscutting.wav
- - "benhillyard" from "freesound.org"
-    * Vocal_Splat_08.wav
- - "Bidone" from "freesound.org"
-    * Affen schreit.mp3
- - "cats2009" from "freesound.org"
-    * blue_angels.wav
- - "cfork" from "freesound.org"
-    * boing_raw.aif
- - "conny" from "freesound.org"
-    * DATSUN_T.wav
- - David R Barnes ("earthcalling"
-    * Corner of a sheep field in summer
- - "ddub" from "freesound.org"
-    * concorde.mp3
- - Derek Murphy ("robbiesurp" at "freesound.org")
-    * wfl5.5_snap.wav
- - "www.digifishmusic.com" ("digifishmusic" at "freesound.org")
-    * Passenger jet departs 2.wav
- - "dobroide" from "freesound.org"
-    * 20060419.horse.neigh.wav
- - Elaine Miller ("Miselaineous" at "freesound.org")
-    * elaine-growl.wav
- - "Goldy-sama" from "freesound.org"
-    * bulle.wav
- - "Halleck" from "freesound.org"
-    * JacobsLadderLong2.flac
- - "han1" from "freesound.org"
-    * Car start and drive.mp3
-    * claxon.wav
- - "HerbertBoland" from "freesound.org"
-    * MouthPop.wav
- - huha from "tt-forums.net"
-    * maglev_sound_2.wav
- - "icmusic" from "freesound.org"
-    * london bus approaches & leaves.wav
- - Janis Lukss ("Pendrokar" at "wiki.openttd.org")
-    * Own recordings/mixes
- - "jascha" from "freesound.org"
-    * kick_1.wav
- - "JFBSAUVE" from "freesound.org"
-    * CHAINSAW.wav
- - Jillian Callahan ("JillianCallahan" at "freesound.org")
-    * generic prop_start(8.395).wav
- - "joedeshon" from "freesound.org"
-    * slide_whistle_down_fast_01.wav
- - "krillion" from "freesound.org"
-    * flyby.mp3
- - "l0calh05t" from "freesound.org"
-    * in the smithy 2.wav
- - "Leady" from "freesound.org"
-    * Dropping a large gun.wav
- - Leon Milo ("milo" at "freesound.org")
-    * msfinmarken_Bergen.aif
-    * ship2_bergen.aif
- - lonemonk from "freesound.org"
-    * Approx 850 - Enthusiast Audience.wav
- - "lorenzosu" from "freesound.org"
-    * helicopterRaw_16sec.wav
- - "man" from "freesound.org"
-    * swosh.aif
- - "Marec" from "freesound.org"
-    * metro.wav
- - "Matias.Reccius" from "freesound.org"
-    * crashB.wav
- - "Necrosensual" from "freesound.org"
-    * aluminum02.wav
- - "NoiseCollector" from "freesound.org"
-    * CRASH2.wav
- - "patchen" from "freesound.org"
-    * Locomotive 1 Distant horn.wav
- - "Pooleside" from "freesound.org"
-    * nnb04_maxed.wav
- - Remko Bijker ("Rubidium" at "dev.openttdcoop.org")
-    * Own work
- - Richard Frohlich ("FreqMan" at "freesound.org")
-    * whoosh06.wav
- - Robert Gacek ("Robinhood76" at "freesound.org")
-    * 01063 roadworks driller.wav
- - "roscoetoon" from "freesound.org"
-    * rr_cross5.wav
-    * t_start1.mp3
- - "Q.K." from "freesound.org"
-    * Metal_03.wav
- - "sagetyrtle" from "freesound.org"
-    * crash.wav
- - "saphix" from "freesound.org"
-    * file0375.mp3
- - "scuola_rocca_di_botte" from "freesound.org"
-    * Manuel Tarquini.wav
- - "Sedi" from "freesound.org"
-    * ae_51_m.wav
- - "simon.rue" from "freesound.org"
-    * Boink_v3.wav
- - "SlykMrByches" from "freesound.org"
-    * splattt.mp3
- - "Stickinthemud" from "freesound.org"
-    * Bike Horn double toot.wav
- - "suonho" from "freesound.org"
-    * ELEMENTS_WATER_02_Phasin-bubbles.wav
- - "tigersound" from "freesound.org"
-    * bird tweet.aif
-    * bird tweet 4.aif
- - Timo A. Hummel ("Felicitus" at "dev.openttdcoop.org")
-    * Own work
- - Tom Haigh ("audible-edge" at "freesound.org")
-    * Nissan Maxima burnout (04-25-2009).wav
- - "VEXST" from "freesound.org"
-    * Snare 4.wav
+Most sounds come from freesound.org and pdsounds.org and were edited
+by OpenTTD contributors in order to make them suitable for the game. Most
+source sounds have been released under libre licenses like CC BY 3.0,
+allowing sharing and remixing.
+However, the actual sounds in OpenSFX also have the editor(s) as
+co-author(s), thus the real OpenSFX sounds do not fall under these
+libre licenses, but under the CC Sampling Plus 1.0 license.
 
+To see detailed license info about the actual sound files in OpenSFX,
+see "src/opensfx.sfo" in the source repository.
+
+4.1) Sound credits of source sounds
+==== ==============================
+This section gives credit to the original sound authors, i.e. the
+sounds before they were edited. All sounds are sorted by their license
+or legal status.
+The name of the author, the origin website, the original file name
+and the URL (if available) are given, in this order.
+
+4.1.1) Public Domain
+====== =============
+* "Aldor" from "pdsounds.org"
+    * Ascenseur / Elevator
+* David R Barnes ("earthcalling") from "pdsounds.org"
+    * Corner of a sheep field in summer
+
+4.1.2) CC0 1.0
+====== =======
+* "1sticky8" from "freesound.org"
+    * Dumpster_Diving.wav <https://freesound.org/people/1sticky8/sounds/78484/>
+* "Bidone" from "freesound.org"
+    * Affen schreit.mp3 <https://freesound.org/people/Bidone/sounds/67361/>
+* Elaine Miller ("Miselaineous" at "freesound.org")
+    * elaine-growl.wav <https://freesound.org/people/Miselaineous/sounds/63668/>
+* "Matias.Reccius" from "freesound.org"
+    * crashB.wav <https://freesound.org/people/Matias.Reccius/sounds/45102/>
+* "Necrosensual" from "freesound.org"
+    * aluminum02.wav <https://freesound.org/people/Necrosensual/sounds/33906/>
+* "Q.K." from "freesound.org"
+    * Metal_03.wav <https://freesound.org/people/Q.K./sounds/56253/>
+* "sagetyrtle" from "freesound.org"
+    * crash.wav <https://freesound.org/people/sagetyrtle/sounds/40158/>
+* "saphix" from "freesound.org"
+    * file0375.mp3 <https://freesound.org/people/saphix/sounds/36794/>
+* "simon.rue" from "freesound.org"
+    * Boink_v3.wav <https://freesound.org/people/simon.rue/sounds/61847/>
+* "SlykMrByches" from "freesound.org"
+    * splattt.mp3 <https://freesound.org/people/SlykMrByches/sounds/55234/>
+* Tom Haigh ("audible-edge" at "freesound.org")
+    * Nissan Maxima burnout (04-25-2009).wav <https://freesound.org/people/audible-edge/sounds/71740/>
+
+4.1.2) CC BY 3.0
+====== =========
+
+* "AGFX" from "freesound.org"
+    * Squeeky ball Toy_1.L.wav <https://freesound.org/people/AGFX/sounds/42940/>
+* "Anton" from "freesound.org"
+    * wind1.wav <https://freesound.org/people/Anton/sounds/2690/>
+* "Benboncan" from "freesound.org"
+    * Circular saw crosscutting.wav <https://freesound.org/people/Benboncan/sounds/60178/>
+* "cfork" from "freesound.org"
+    * boing_raw.aif <https://freesound.org/people/cfork/sounds/7967/>
+* Derek Murphy ("robbiesurp" at "freesound.org")
+    * wfl5.5_snap.wav <https://freesound.org/people/robbiesurp/sounds/3154/>
+* "www.digifishmusic.com" ("digifishmusic" at "freesound.org")
+    * Passenger jet departs 2.wav <https://freesound.org/people/digifishmusic/sounds/54965/>
+* "dobroide" from "freesound.org"
+    * 20060419.horse.neigh.wav <https://freesound.org/people/dobroide/sounds/18229/>
+* "Goldy-sama" from "freesound.org"
+    * bulle.wav <https://freesound.org/people/Goldy-sama/sounds/4239/>
+* "Halleck" from "freesound.org"
+    * JacobsLadderLong2.flac <https://freesound.org/people/Halleck/sounds/19483/>
+* "han1" from "freesound.org"
+    * Car start and drive.mp3 <https://freesound.org/people/han1/sounds/19025/>
+    * claxon.wav <https://freesound.org/people/han1/sounds/19026/>
+* "HerbertBoland" from "freesound.org"
+    * MouthPop.wav <https://freesound.org/people/HerbertBoland/sounds/33369/>
+* "man" from "freesound.org"
+    * swosh.aif <https://freesound.org/people/man/sounds/14609/>
+* "Marec" from "freesound.org"
+    * metro.wav <https://freesound.org/people/Marec/sounds/17601/>
+* "icmusic" from "freesound.org"
+    * london bus approaches & leaves.wav <https://freesound.org/people/icmusic/sounds/36897/>
+* "jascha" from "freesound.org"
+    * kick_1.wav <https://freesound.org/people/jascha/sounds/2837/>
+* "JFBSAUVE" from "freesound.org"
+    * CHAINSAW.wav <https://freesound.org/people/JFBSAUVE/sounds/19898/>
+* "joedeshon" from "freesound.org"
+    * slide_whistle_down_fast_01.wav <https://freesound.org/people/joedeshon/sounds/79672/>
+* "l0calh05t" from "freesound.org"
+    * in the smithy 2.wav <https://freesound.org/people/l0calh05t/sounds/19027/>
+* "Leady" from "freesound.org"
+    * Dropping a large gun.wav <https://freesound.org/people/Leady/sounds/12735/>
+* Leon Milo ("milo" at "freesound.org")
+    * msfinmarken_Bergen.aif <https://freesound.org/people/milo/sounds/23452/>
+    * ship2_bergen.aif <https://freesound.org/people/milo/sounds/23722/>
+* lonemonk from "freesound.org"
+    * Approx 850 - Enthusiast Audience.wav <https://freesound.org/people/lonemonk/sounds/31169/>
+* "NoiseCollector" from "freesound.org"
+    * CRASH2.wav <https://freesound.org/people/NoiseCollector/sounds/2792/>
+* "patchen" from "freesound.org"
+    * Locomotive 1 Distant horn.wav <https://freesound.org/people/patchen/sounds/17851/>
+* "Pooleside" from "freesound.org"
+    * nnb04_maxed.wav <https://freesound.org/people/Pooleside/sounds/21558/>
+  * Richard Frohlich ("FreqMan" at "freesound.org")
+    * whoosh06.wav <https://freesound.org/people/FreqMan/sounds/25074/>
+* "roscoetoon" from "freesound.org"
+    * rr_cross5.wav <https://freesound.org/people/roscoetoon/sounds/26385/>
+    * t_start1.mp3 <https://freesound.org/people/roscoetoon/sounds/26814/>
+* "Sedi" from "freesound.org"
+    * ae_51_m.wav <https://freesound.org/people/Sedi/sounds/70899/>
+* "Stickinthemud" from "freesound.org"
+    * Bike Horn double toot.wav <https://freesound.org/people/Stickinthemud/sounds/27882/>
+* "suonho" from "freesound.org"
+    * ELEMENTS_WATER_02_Phasin-bubbles.wav <https://freesound.org/people/suonho/sounds/17783/>
+* "VEXST" from "freesound.org"
+    * Snare 4.wav <https://freesound.org/people/VEXST/sounds/26903/>
+
+4.1.3) CC BY-SA 3.0
+====== ============
+* Lorenzo Sutton ("lorenzosu" at "freesound.org"):
+    * helicopterRaw_16sec.wav <https://archive.org/details/helicopterRaw_16sec>
+
+4.1.4) CC BY-NC 3.0
+====== ============
+* "acclivity" from "freesound.org"
+    * ChugChugWooHoo.mp3 <https://freesound.org/people/acclivity/sounds/31626/>
+    * TwoCows.wav <https://freesound.org/people/acclivity/sounds/16568/>
+* "benhillyard" from "freesound.org"
+    * Vocal_Splat_08.wav <https://freesound.org/people/benhillyard/sounds/47980/>
+* Robert Gacek ("Robinhood76" at "freesound.org")
+    * 01063 roadworks driller.wav <https://freesound.org/people/Robinhood76/sounds/73623/>
+ * "tigersound" from "freesound.org"
+    * bird tweet.aif <https://freesound.org/people/tigersound/sounds/9328/>
+    * bird tweet 4.aif <https://freesound.org/people/tigersound/sounds/9327/>
+
+4.1.5) CC Sampling Plus 1.0
+====== ====================
+* "cats2009" from "freesound.org"
+    * blue_angels.wav <https://freesound.org/people/cats2009/sounds/72713/>
+* "conny" from "freesound.org"
+    * DATSUN_T.wav <https://freesound.org/people/conny/sounds/2937/>
+* "ddub" from "freesound.org"
+    * concorde.mp3 <https://freesound.org/people/ddub/sounds/25464/>
+* Jillian Callahan ("JillianCallahan" at "freesound.org")
+    * generic prop_start(8.395).wav <https://freesound.org/people/JillianCallahan/sounds/12815/>
+* "krillion" from "freesound.org"
+    * flyby.mp3 <https://freesound.org/people/krillion/sounds/34622/>
+* "scuola_rocca_di_botte" from "freesound.org"
+    * Manuel Tarquini.wav <https://freesound.org/people/scuola_rocca_di_botte/sounds/17277/>
+
+4.1.6) Unknown license
+====== ===============
+* "alexrigg" from "freesound.org"
+    * crash_treefall_SE.mp3
+* huha from "tt-forums.net"
+    * maglev_sound_2.wav
+
+4.2) Sound editors
+==== =============
 Editing/(re)mixing was done by:
- - Janis Lukss ("Pendrokar" at "wiki.openttd.org")
- - "janusz" from "dev.openttdcoop.org"
- - "Jklamo" from "wiki.opentd.org"
- - Remko Bijker ("Rubidium" at "dev.openttdcoop.org")
- - Richard Wheeler ("Zephyris" at "dev.openttdcoop.org")
+* Janis Lukss ("Pendrokar" at "wiki.openttd.org")
+* "janusz" from "dev.openttdcoop.org"
+* "Jklamo" from "wiki.openttd.org"
+* Remko Bijker ("Rubidium" at "dev.openttdcoop.org")
+* Richard Wheeler ("Zephyris" at "dev.openttdcoop.org")
 
 A detailed list of who has worked on what sample is available in the
-file opensfx.sfo in the source repository.
+file "src/opensfx.sfo" in the source repository.
 
+4.3) Other authors
+==== =============
+This is a list of sound creators that contributed
+their work directly to OpenSFX:
+* Janis Lukss ("Pendrokar" at "wiki.openttd.org")
+    * Own recordings/mixes
+* Timo A. Hummel ("Felicitus" at "dev.openttdcoop.org")
+    * Own work
+* Remko Bijker ("Rubidium" at "dev.openttdcoop.org")
+    * Own work
+
+4.4) License reference
+==== =================
+You can find the complete license texts here:
+
+* CC0 1.0: <https://creativecommons.org/publicdomain/zero/1.0/>
+* CC BY 3.0: <http://creativecommons.org/licenses/by/3.0/>
+* CC BY-SA 3.0: <http://creativecommons.org/licenses/by-sa/3.0/>
+* CC BY-NC 3.0: <http://creativecommons.org/licenses/by-nc/3.0/>
+* CC Sampling Plus 1.0: <https://creativecommons.org/licenses/sampling+/1.0/>
+
+5.0) Acknowledgements
+==== ================
 Thanks go out to the guys at #openttdcoop for providing the source
 repository and bug tracking services.


### PR DESCRIPTION
I have looked up all the sound sources mentioned in the README and made the list more accessible by also including the URL (if possible) and sorting everything by license. This will help a lot with the 'liberation' (#2). =)

In the README there were also various false claims about the legal status, such as that OpenSFX really is 'open source' (which definitely it isn't because of CC Sampling Plus), so I replaced those with more direct and clarifying language.

I have checked if I did not accidentally remove a sound from the list, just to be sure. But please look closely at my edit for yourself.