### PR TITLE
Change: Relicense sounds edited by Pendrokar and zephyris to CC BY 3.0

### DIFF
--- a/src/opensfx.sfo
+++ b/src/opensfx.sfo
@@ -1,40 +1,40 @@
 // "file name" internal name
-"src/wav/osfx_00.wav" "Good Year". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_01.wav" "Bad Year". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_00.wav" "Good Year". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_01.wav" "Bad Year". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_02.wav" "Splat (building docks/canals/river)". Original "splattt.mp3" by "SlykMrByches". Edited by Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_03.wav" "Factory Whistle". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_03.wav" "Factory Whistle". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_04.wav" "Steam train station departure". Original "steam train horn 01.wav" by "eliasheuninck". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_05.wav" "Steam engine going in tunnel". Original "steam train horn 01.wav" by "eliasheuninck". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_06.wav" "Ship horn". Original "ship2_bergen.aif" by Leon Milo. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_07.wav" "Ferry horn". Original "msfinmarken_Bergen.aif" by Leon Milo. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_08.wav" "Propeller plane start". Original "Plane Cessna start stop.wav" by "Cheeseheadburger". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_09.wav" "Early jet take off". Original "Passenger jet departs 2.wav" by "www.digifishmusic.com". License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_10.wav" "Diesel/electric train station departure". Original "Locomotive 1 Distant horn.wav" by "patchen". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_11.wav" "Mining machinery". Original "L'ascenseur - Elevator" by "Aldor". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License, original is Public Domain.
-"src/wav/osfx_12.wav" "Electric sparking". Original "JacobsLadderLong2.flac" by "Halleck". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_13.wav" "Steam (of steam engine)". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_10.wav" "Diesel/electric train station departure". Original "Locomotive 1 Distant horn.wav" by "patchen". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_11.wav" "Mining machinery". Original "L'ascenseur - Elevator" by "Aldor". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported. Original is Public Domain.
+"src/wav/osfx_12.wav" "Electric sparking". Original "JacobsLadderLong2.flac" by "Halleck". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_13.wav" "Steam (of steam engine)". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_14.wav" "Level crossing". Original "RRCrossing.wav" by "Mark_Ian". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_15.wav" "Road vehicle breakdown". Original "Dropping a large gun.wav" by "Leady". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_15.wav" "Road vehicle breakdown". Original "Dropping a large gun.wav" by "Leady". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_16.wav" "Train/ship breakdown". Original "Dumpster_Diving.wav" by "1sticky8". Edited by Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_17.wav" "Crash". Original "crash.wav" by "sagetyrtle". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_18.wav" "Explosion". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_19.wav" "Big crash". Original "crash.wav" by "sagetyrtle". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_20.wav" "Cash till". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_21.wav" "Beep". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_22.wav" "Morse". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_17.wav" "Crash". Original "crash.wav" by "sagetyrtle". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_18.wav" "Explosion". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_19.wav" "Big crash". Original "crash.wav" by "sagetyrtle". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_20.wav" "Cash till". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_21.wav" "Beep". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_22.wav" "Morse". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_23.wav" "Plane wheels touching ground". Original "Nissan Maxima burnout (04-25-2009).wav" by Tom Haigh. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_24.wav" "Helicopter". Original "helicopterRaw_16sec.wav" by "lorenzosu". Edited by "Jklamo". License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_25.wav" "Bus start, pull away". Original "file0375.mp3" by "saphix". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_26.wav" "Bus start, pull away with horn". Original "file0375.mp3" by "saphix" and "Industrial Air Horn.wav" by "mcpable". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_27.wav" "Old truck start". Original "t_start1.mp3" by "roscoetoon". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_28.wav" "Modern truck start". Original "london bus approaches & leaves.wav" by "icmusic". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_27.wav" "Old truck start". Original "t_start1.mp3" by "roscoetoon". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_28.wav" "Modern truck start". Original "london bus approaches & leaves.wav" by "icmusic". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_29.wav" "Applause". Original "Approx 850 - Enthusiast Audience.wav" by "lonemonk". Edited by Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_30.wav" "Oooh sound". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_31.wav" "Splat (terraform/non-rail builds". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_30.wav" "Oooh sound". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_31.wav" "Splat (terraform/non-rail builds". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_32.wav" "Splat (rail builds)". Original "kick_1.wav" by "jascha". License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_33.wav" "Jackhammer". Original "air hammer half close.wav" by "Bluesy1905". Cut and edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
-"src/wav/osfx_34.wav" "Unused/Nothing | {{REPO_TITLE}}". By Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_35.wav" "Modern car horn". Original "claxon.wav" by "han1". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_34.wav" "Unused/Nothing". Trivial empty sound file. License: Creative Commons Zero 1.0.
+"src/wav/osfx_35.wav" "Modern car horn". Original "claxon.wav" by "han1". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_36.wav" "Sheep". Original "Corner of a sheep field in summer" by David R Barnes. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_37.wav" "Cow". Original "Cow - Moan 2 - 96kHz.wav" by "Jarred Gib". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_38.wav" "Horse". Original "20060419.horse.neigh.wav" by "dobroide". Edited by "Jklamo". License: Creative Commons Sampling Plus 1.0 License.
@@ -43,32 +43,32 @@
 "src/wav/osfx_41.wav" "Toyland: Sugar mine (1)". Original "shaker2.wav" by "marvman". Cut and edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_42.wav" "Toyland: Toy factory (1)". Original "ae_51_m.wav" by "Sedi", "vial-glass-square-cinnamon-sticks-open-02.wav" by Jan Schupke aka "Vehicle" and "whoosh06.wav" by Richard Frohlich aka "FreqMan". Edited by "Wuzzy". License: Creative Commons Attribution 3.0.
 "src/wav/osfx_43.wav" "Toyland: Toy factory (2)". Original "ae_51_m.wav" by "Sedi" and "Slide Whistle, Descending, B (H1).wav" by "InspectorJ". Edited and mixed by "Wuzzy". License: Creative Commons Attribution 3.0.
-"src/wav/osfx_44.wav" "Toyland: Toy factory (3)". Orignal "nnb04_maxed.wav" by "Pooleside". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_44.wav" "Toyland: Toy factory (3)". Orignal "nnb04_maxed.wav" by "Pooleside". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_45.wav" "Toyland: Sugar mine (2)". Original "shaker2.wav" by "marvman". Cut and edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_46.wav" "Toyland: Bubble extraction (1)". By Timo A. Hummel. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_47.wav" "Toyland: Bubble plop". By Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_48.wav" "Toyland: Toffee quarry". Original "Metal_03.wav" by "Q.K.", "aluminum02.wav" by "Necrosensual" and "slide_whistle_down_fast_01.wav" by "joedeshon". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_47.wav" "Toyland: Bubble plop". By Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_48.wav" "Toyland: Toffee quarry". Original "Metal_03.wav" by "Q.K.", "aluminum02.wav" by "Necrosensual" and "slide_whistle_down_fast_01.wav" by "joedeshon". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_49.wav" "Toyland: Bubble extraction (2)". By Timo A. Hummel. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_50.wav" "Unused/Nothing". By Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_51.wav" "Toyland: Plastic mine". Original "bulle.wav" by "Goldy-sama" and "ELEMENTS_WATER_02_Phasin-bubbles.wav" by "suonho". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_52.wav" "Wind". Original "wind1.wav" by "Anton". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_53.wav" "Toyland: Road vehicle breakdown". Original "CRASH2.wav" by "NoiseCollector" and "Snare 4.wav" by "VEXST". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_50.wav" "Unused/Nothing". Trivial empty sound file. License: Creative Commons Zero 1.0.
+"src/wav/osfx_51.wav" "Toyland: Plastic mine". Original "bulle.wav" by "Goldy-sama" and "ELEMENTS_WATER_02_Phasin-bubbles.wav" by "suonho". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_52.wav" "Wind". Original "wind1.wav" by "Anton". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_53.wav" "Toyland: Road vehicle breakdown". Original "CRASH2.wav" by "NoiseCollector" and "Snare 4.wav" by "VEXST". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_54.wav" "Lumber mill: Crashing tree". Original "A Tree Falling Down.wav" by "ecfike". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_55.wav" "Lumber mill: Falling tree". Original "cutting_tree.wav" by "fkurz". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_56.wav" "Lumber mill: Chainsaw". Original "CHAINSAW.wav" by "JFBSAUVE". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_57.wav" "Heavy wind". Original "wind1.wav" by "Anton". Edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_58.wav" "Toyland: Train breakdown". Original "wfl5.5_snap.wav" by Derek Murphy and "crashB.wav" by "Matias.Reccius". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_56.wav" "Lumber mill: Chainsaw". Original "CHAINSAW.wav" by "JFBSAUVE". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_57.wav" "Heavy wind". Original "wind1.wav" by "Anton". Edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_58.wav" "Toyland: Train breakdown". Original "wfl5.5_snap.wav" by Derek Murphy and "crashB.wav" by "Matias.Reccius". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_59.wav" "Mach 1+ Jet take off". Original "Landing Jet 5 (Close).wav" by "bigpickle51". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
-"src/wav/osfx_60.wav" "Toyland: Comedy bus start (1)". Original "file0375.mp3" by "saphix" and "boing_raw.aif" by "cfork". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_60.wav" "Toyland: Comedy bus start (1)". Original "file0375.mp3" by "saphix" and "boing_raw.aif" by "cfork". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_61.wav" "Modern jet take off". Original "5_Navy-Blue-Angels-jets_CLIP.wav" by ibisradio. Edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_62.wav" "Toyland: Comedy bus start (2)". Original "file0375.mp3" by "saphix" and "Bike Horn double toot.wav" by "Stickinthemud". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_63.wav" "Toyland: Comedy truck start (1)". Original "t_start1.mp3" by "roscoetoon" and "Squeeky ball Toy_1.L.wav" by "AGFX". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_64.wav" "Toyland: Comedy truck start (2)". Original "london bus approaches & leaves.wav" by "icmusic" and "Boink_v3.wav" by "simon.rue". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
-"src/wav/osfx_65.wav" "Maglev train station departure". Original "metro.wav" by "Marec". Mixed/edited by Janis Lukss. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_62.wav" "Toyland: Comedy bus start (2)". Original "file0375.mp3" by "saphix" and "Bike Horn double toot.wav" by "Stickinthemud". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_63.wav" "Toyland: Comedy truck start (1)". Original "t_start1.mp3" by "roscoetoon" and "Squeeky ball Toy_1.L.wav" by "AGFX". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_64.wav" "Toyland: Comedy truck start (2)". Original "london bus approaches & leaves.wav" by "icmusic" and "Boink_v3.wav" by "simon.rue". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_65.wav" "Maglev train station departure". Original "metro.wav" by "Marec". Mixed/edited by Janis Lukss. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_66.wav" "Tropical: Bird (1)". Original "Bird Noise - 1.wav" by "SpaceJoe". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_67.wav" "Tropical: Lion roar". Original "elaine-growl.wav" by Elaine Miller. Edited by Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_68.wav" "Tropical: Monkeys". Original "Affen schreit.mp3" by "Bidone". Edited by Remko Bijker. License: Creative Commons Sampling Plus 1.0 License.
 "src/wav/osfx_69.wav" "Toyland: Propeller plane take off". Original "Airplane propeller.wav" by "MrVasLuk". Edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_70.wav" "Toyland: Jet take off". Original "Passenger jet departs 2.wav" by "www.digifishmusic.com", "Car start and drive.mp3" by "han1" and "swosh.aif" by "man". Edited by Richard Wheeler. License: Creative Commons Sampling Plus 1.0 License.
+"src/wav/osfx_70.wav" "Toyland: Jet take off". Original "Passenger jet departs 2.wav" by "www.digifishmusic.com", "Car start and drive.mp3" by "han1" and "swosh.aif" by "man". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_71.wav" "Monorail train station departure". Original "Train passby (tape stop).wav" by "Metzik". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_72.wav" "Tropical: Bird (2)". Original "Bird Noise - 12.wav" by "SpaceJoe". Edited by "Wuzzy". License: Creative Commons Zero 1.0.


### PR DESCRIPTION
This PR will change the license of sounds edited by Pendrokar and zephyris to CC BY 3.0, as discussed in #6. The source sounds that these sounds are based on are all either CC BY 3.0 or CC0.

Additionally, `osfx_34` and `osfx_50` are relicensed under CC0 because those are just trivial empty sounds that can be recreated within seconds in Audacity, it's silly to claim any copyright on them.