### PR TITLE
Shorten some description texts

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,7 +1,7 @@
 1.0.0 (TBD)
 ------------------------------------------------------------------------
 -Change: Many sounds were replaced and reworked
--Change: New licenses: CC BY-SA 3.0, GPLv2+, CDDL 1.1 (was: CC Sampling Plus)
+-Change: License: CC BY-SA 3.0, GPLv2+, CDDL 1.1 (was: CC Sampling Plus)
 
 
 0.2.3 (2010-03-31)

--- a/docs/license.txt
+++ b/docs/license.txt
@@ -1,14 +1,14 @@
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 OVERVIEW
------------------------------------------------------------------------------
-This is the OpenSFX license file. To see how these licenses apply to OpenSFX,
-see the readme file.
+------------------------------------------------------------------------
+This is the OpenSFX license file. To see how these licenses apply to
+OpenSFX, see the readme file.
 
 The full license texts that apply to OpenSFX are given below:
 
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 CREATIVE COMMONS ATTRIBUTION SHAREALIKE 3.0 UNPORTED (CC BY-SA 3.0)
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
 COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
 COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
@@ -360,9 +360,9 @@ Creative Commons Notice
 
 
 
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 GNU GENERAL PUBLIC LICENSE VERSION 2 (GNU GPLv2)
------------------------------------------------------------------------------
+------------------------------------------------------------------------
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
@@ -648,9 +648,9 @@ POSSIBILITY OF SUCH DAMAGES.
 
 
 
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 1. Definitions.
 
@@ -1001,7 +1001,8 @@ COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
   responsibility on an equitable basis. Nothing herein is intended or
   shall be deemed to constitute any admission of liability.
 
-NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
+NOTICE PURSUANT TO SECTION 9 OF THE
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
 
 The code released under the CDDL shall be governed by the laws of the
 State of California (excluding conflict-of-law provisions). Any
@@ -1010,6 +1011,6 @@ of the Federal Courts of the Northern District of California and the
 state courts of the State of California, with venue lying in Santa Clara
 County, California.
 
------------------------------------------------------------------------------
+------------------------------------------------------------------------
 END OF LICENSE FILE
------------------------------------------------------------------------------
+------------------------------------------------------------------------

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -185,137 +185,201 @@ and the URL (if available) are given, in this order.
 4.1.2) CC0 1.0
 ====== =======
 * "1sticky8" from "freesound.org"
-    * Dumpster_Diving.wav <https://freesound.org/people/1sticky8/sounds/78484/>
+    * Dumpster_Diving.wav
+      https://freesound.org/people/1sticky8/sounds/78484/
 * "Bidone" from "freesound.org"
-    * Affen schreit.mp3 <https://freesound.org/people/Bidone/sounds/67361/>
+    * Affen schreit.mp3
+      https://freesound.org/people/Bidone/sounds/67361/
 * Elaine Miller ("Miselaineous" at "freesound.org")
-    * elaine-growl.wav <https://freesound.org/people/Miselaineous/sounds/63668/>
+    * elaine-growl.wav
+      https://freesound.org/people/Miselaineous/sounds/63668/
 * "Matias.Reccius" from "freesound.org"
-    * crashB.wav <https://freesound.org/people/Matias.Reccius/sounds/45102/>
+    * crashB.wav
+      https://freesound.org/people/Matias.Reccius/sounds/45102/
 * "Necrosensual" from "freesound.org"
-    * aluminum02.wav <https://freesound.org/people/Necrosensual/sounds/33906/>
+    * aluminum02.wav
+      https://freesound.org/people/Necrosensual/sounds/33906/
 * "Q.K." from "freesound.org"
-    * Metal_03.wav <https://freesound.org/people/Q.K./sounds/56253/>
+    * Metal_03.wav
+      https://freesound.org/people/Q.K./sounds/56253/
 * "sagetyrtle" from "freesound.org"
-    * crash.wav <https://freesound.org/people/sagetyrtle/sounds/40158/>
+    * crash.wav
+      https://freesound.org/people/sagetyrtle/sounds/40158/
 * "saphix" from "freesound.org"
-    * file0375.mp3 <https://freesound.org/people/saphix/sounds/36794/>
+    * file0375.mp3
+      https://freesound.org/people/saphix/sounds/36794/
 * "simon.rue" from "freesound.org"
-    * Boink_v3.wav <https://freesound.org/people/simon.rue/sounds/61847/>
+    * Boink_v3.wav
+      https://freesound.org/people/simon.rue/sounds/61847/
 * "SlykMrByches" from "freesound.org"
-    * splattt.mp3 <https://freesound.org/people/SlykMrByches/sounds/55234/>
+    * splattt.mp3
+      https://freesound.org/people/SlykMrByches/sounds/55234/
 * Tom Haigh ("audible-edge" at "freesound.org")
-    * Nissan Maxima burnout (04-25-2009).wav <https://freesound.org/people/audible-edge/sounds/71740/>
+    * Nissan Maxima burnout (04-25-2009).wav
+      https://freesound.org/people/audible-edge/sounds/71740/
 * "Metzik" from "freesound.org"
-    * Train passby (tape stop).wav <https://freesound.org/people/Metzik/sounds/387878/>
+    * Train passby (tape stop).wav
+      https://freesound.org/people/Metzik/sounds/387878/
 * "SpaceJoe" from "freesound.org"
-    * Bird Noise - 1.wav <https://freesound.org/people/SpaceJoe/sounds/507257/>
-    * Bird Noise - 12.wav <https://freesound.org/people/SpaceJoe/sounds/507254/>
+    * Bird Noise - 1.wav
+      https://freesound.org/people/SpaceJoe/sounds/507257/
+    * Bird Noise - 12.wav
+      https://freesound.org/people/SpaceJoe/sounds/507254/
 * "MrVasLuk" from "freesound.org"
-    * Airplane propeller.wav <https://freesound.org/people/MrVasLuk/sounds/333203/>
+    * Airplane propeller.wav
+      https://freesound.org/people/MrVasLuk/sounds/333203/
 * "ibisradio" from "freesound.org"
-    * 5_Navy-Blue-Angels-jets_CLIP.wav <https://freesound.org/people/ibisradio/sounds/328446/>
+    * 5_Navy-Blue-Angels-jets_CLIP.wav
+      https://freesound.org/people/ibisradio/sounds/328446/
 * "mcpable" from "freesound.org"
-    * Industrial Air Horn.wav <https://freesound.org/people/mcpable/sounds/131930/>
+    * Industrial Air Horn.wav
+      https://freesound.org/people/mcpable/sounds/131930/
 * "ecfike" from "freesound.org"
-    * A Tree Falling Down.wav <https://freesound.org/people/ecfike/sounds/139952/>
+    * A Tree Falling Down.wav
+      https://freesound.org/people/ecfike/sounds/139952/
 * "fkurz" from "freesound.org"
-    * cutting_tree.wav <https://freesound.org/people/fkurz/sounds/169127/>
+    * cutting_tree.wav
+      https://freesound.org/people/fkurz/sounds/169127/
 * "JarredGibb" from "freesound.org"
-    * Cow - Moan 2 - 96kHz.wav <https://freesound.org/people/JarredGibb/sounds/233146/>
+    * Cow - Moan 2 - 96kHz.wav
+      https://freesound.org/people/JarredGibb/sounds/233146/
 * "marvman" from "freesound.org"
-    * shaker2.wav <https://freesound.org/people/marvman/sounds/51317/>
+    * shaker2.wav
+      https://freesound.org/people/marvman/sounds/51317/
 * Jan Schupke alias "Vehicle" from "opengameart.org"
-    * vial-glass-square-cinnamon-sticks-open-02.wav <https://opengameart.org/content/fantasy-accessory-sfx-library>
+    * vial-glass-square-cinnamon-sticks-open-02.wav
+      https://opengameart.org/content/fantasy-accessory-sfx-library
 * "Mark_Ian" from "freesound.org"
-    * RRCrossing.wav <https://freesound.org/people/Mark_Ian/sounds/240639/>
+    * RRCrossing.wav
+      https://freesound.org/people/Mark_Ian/sounds/240639/
 * "Beviceps" from "freesound.org"
-    * Cartoon - Slurp!.wav <https://freesound.org/people/Breviceps/sounds/445974/>
+    * Cartoon - Slurp!.wav
+      https://freesound.org/people/Breviceps/sounds/445974/
 * "ristooooo1" from "freesound.org"
-    * Bubbles 001.wav <https://freesound.org/people/ristooooo1/sounds/539823/>
+    * Bubbles 001.wav
+      https://freesound.org/people/ristooooo1/sounds/539823/
 * "musicmasta1" from "freesound.org"
-    * CarStartSkidCrash.wav <https://freesound.org/people/musicmasta1/sounds/131385/>
+    * CarStartSkidCrash.wav
+      https://freesound.org/people/musicmasta1/sounds/131385/
 
 4.1.2) CC BY 3.0
 ====== =========
 
 * "AGFX" from "freesound.org"
-    * Squeeky ball Toy_1.L.wav <https://freesound.org/people/AGFX/sounds/42940/>
+    * Squeeky ball Toy_1.L.wav
+      https://freesound.org/people/AGFX/sounds/42940/
 * "Anton" from "freesound.org"
-    * wind1.wav <https://freesound.org/people/Anton/sounds/2690/>
+    * wind1.wav
+      https://freesound.org/people/Anton/sounds/2690/
 * "Benboncan" from "freesound.org"
-    * Circular saw crosscutting.wav <https://freesound.org/people/Benboncan/sounds/60178/>
+    * Circular saw crosscutting.wav
+      https://freesound.org/people/Benboncan/sounds/60178/
 * "cfork" from "freesound.org"
-    * boing_raw.aif <https://freesound.org/people/cfork/sounds/7967/>
+    * boing_raw.aif
+      https://freesound.org/people/cfork/sounds/7967/
 * Derek Murphy ("robbiesurp" at "freesound.org")
-    * wfl5.5_snap.wav <https://freesound.org/people/robbiesurp/sounds/3154/>
+    * wfl5.5_snap.wav
+      https://freesound.org/people/robbiesurp/sounds/3154/
 * "www.digifishmusic.com" ("digifishmusic" at "freesound.org")
-    * Passenger jet departs 2.wav <https://freesound.org/people/digifishmusic/sounds/54965/>
+    * Passenger jet departs 2.wav
+      https://freesound.org/people/digifishmusic/sounds/54965/
 * "dobroide" from "freesound.org"
-    * 20060419.horse.neigh.wav <https://freesound.org/people/dobroide/sounds/18229/>
+    * 20060419.horse.neigh.wav
+      https://freesound.org/people/dobroide/sounds/18229/
 * "Goldy-sama" from "freesound.org"
-    * bulle.wav <https://freesound.org/people/Goldy-sama/sounds/4239/>
+    * bulle.wav
+      https://freesound.org/people/Goldy-sama/sounds/4239/
 * "Halleck" from "freesound.org"
-    * JacobsLadderLong2.flac <https://freesound.org/people/Halleck/sounds/19483/>
+    * JacobsLadderLong2.flac
+      https://freesound.org/people/Halleck/sounds/19483/
 * "han1" from "freesound.org"
-    * Car start and drive.mp3 <https://freesound.org/people/han1/sounds/19025/>
-    * claxon.wav <https://freesound.org/people/han1/sounds/19026/>
+    * Car start and drive.mp3
+      https://freesound.org/people/han1/sounds/19025/
+    * claxon.wav
+      https://freesound.org/people/han1/sounds/19026/
 * "man" from "freesound.org"
-    * swosh.aif <https://freesound.org/people/man/sounds/14609/>
+    * swosh.aif
+      https://freesound.org/people/man/sounds/14609/
 * "Marec" from "freesound.org"
-    * metro.wav <https://freesound.org/people/Marec/sounds/17601/>
+    * metro.wav
+      https://freesound.org/people/Marec/sounds/17601/
 * "icmusic" from "freesound.org"
-    * london bus approaches & leaves.wav <https://freesound.org/people/icmusic/sounds/36897/>
+    * london bus approaches & leaves.wav
+      https://freesound.org/people/icmusic/sounds/36897/
 * "jascha" from "freesound.org"
-    * kick_1.wav <https://freesound.org/people/jascha/sounds/2837/>
+    * kick_1.wav
+      https://freesound.org/people/jascha/sounds/2837/
 * "JFBSAUVE" from "freesound.org"
-    * CHAINSAW.wav <https://freesound.org/people/JFBSAUVE/sounds/19898/>
+    * CHAINSAW.wav
+      https://freesound.org/people/JFBSAUVE/sounds/19898/
 * "joedeshon" from "freesound.org"
-    * slide_whistle_down_fast_01.wav <https://freesound.org/people/joedeshon/sounds/79672/>
+    * slide_whistle_down_fast_01.wav
+      https://freesound.org/people/joedeshon/sounds/79672/
 * "l0calh05t" from "freesound.org"
-    * in the smithy 2.wav <https://freesound.org/people/l0calh05t/sounds/19027/>
+    * in the smithy 2.wav
+      https://freesound.org/people/l0calh05t/sounds/19027/
 * "Leady" from "freesound.org"
-    * Dropping a large gun.wav <https://freesound.org/people/Leady/sounds/12735/>
+    * Dropping a large gun.wav
+      https://freesound.org/people/Leady/sounds/12735/
 * Leon Milo ("milo" at "freesound.org")
-    * msfinmarken_Bergen.aif <https://freesound.org/people/milo/sounds/23452/>
-    * ship2_bergen.aif <https://freesound.org/people/milo/sounds/23722/>
+    * msfinmarken_Bergen.aif
+      https://freesound.org/people/milo/sounds/23452/
+    * ship2_bergen.aif
+      https://freesound.org/people/milo/sounds/23722/
 * "lonemonk" from "freesound.org"
-    * Approx 850 - Enthusiast Audience.wav <https://freesound.org/people/lonemonk/sounds/31169/>
+    * Approx 850 - Enthusiast Audience.wav
+      https://freesound.org/people/lonemonk/sounds/31169/
 * "NoiseCollector" from "freesound.org"
-    * CRASH2.wav <https://freesound.org/people/NoiseCollector/sounds/2792/>
+    * CRASH2.wav
+      https://freesound.org/people/NoiseCollector/sounds/2792/
 * "patchen" from "freesound.org"
-    * Locomotive 1 Distant horn.wav <https://freesound.org/people/patchen/sounds/17851/>
+    * Locomotive 1 Distant horn.wav
+      https://freesound.org/people/patchen/sounds/17851/
 * "Pooleside" from "freesound.org"
-    * nnb04_maxed.wav <https://freesound.org/people/Pooleside/sounds/21558/>
+    * nnb04_maxed.wav
+      https://freesound.org/people/Pooleside/sounds/21558/
 * Richard Frohlich ("FreqMan" at "freesound.org")
-    * whoosh06.wav <https://freesound.org/people/FreqMan/sounds/25074/>
+    * whoosh06.wav
+      https://freesound.org/people/FreqMan/sounds/25074/
 * "roscoetoon" from "freesound.org"
-    * t_start1.mp3 <https://freesound.org/people/roscoetoon/sounds/26814/>
+    * t_start1.mp3
+      https://freesound.org/people/roscoetoon/sounds/26814/
 * "Sedi" from "freesound.org"
-    * ae_51_m.wav <https://freesound.org/people/Sedi/sounds/70899/>
+    * ae_51_m.wav
+      https://freesound.org/people/Sedi/sounds/70899/
 * "Stickinthemud" from "freesound.org"
-    * Bike Horn double toot.wav <https://freesound.org/people/Stickinthemud/sounds/27882/>
+    * Bike Horn double toot.wav
+      https://freesound.org/people/Stickinthemud/sounds/27882/
 * "suonho" from "freesound.org"
-    * ELEMENTS_WATER_02_Phasin-bubbles.wav <https://freesound.org/people/suonho/sounds/17783/>
+    * ELEMENTS_WATER_02_Phasin-bubbles.wav
+      https://freesound.org/people/suonho/sounds/17783/
 * "VEXST" from "freesound.org"
-    * Snare 4.wav <https://freesound.org/people/VEXST/sounds/26903/>
+    * Snare 4.wav
+      https://freesound.org/people/VEXST/sounds/26903/
 * "bigpickle51" from "freesound.org"
-    * Landing Jet 5 (Close).wav <https://freesound.org/people/bigpickle51/sounds/219469/>
+    * Landing Jet 5 (Close).wav
+      https://freesound.org/people/bigpickle51/sounds/219469/
 * "Cheeseheadburger" from "freesound.org"
-    * Plane Cessna start stop.wav <https://freesound.org/people/Cheeseheadburger/sounds/141519/>
+    * Plane Cessna start stop.wav
+      https://freesound.org/people/Cheeseheadburger/sounds/141519/
 * "eliasheuninck" from "freesound.org"
-    * steam train horn 01.wav <https://freesound.org/people/eliasheuninck/sounds/170464/>
+    * steam train horn 01.wav
+      https://freesound.org/people/eliasheuninck/sounds/170464/
 * "Bluesy1905" from "freesound.org"
-    * air hammer half close.wav <https://freesound.org/people/Bluesy1905/sounds/344934/>
+    * air hammer half close.wav
+      https://freesound.org/people/Bluesy1905/sounds/344934/
 * "InspectorJ" from "freesound.org"
-    * Slide Whistle, Descending, B (H1).wav <https://freesound.org/people/InspectorJ/sounds/410804/>
+    * Slide Whistle, Descending, B (H1).wav
+      https://freesound.org/people/InspectorJ/sounds/410804/
 * "swordofkings128" from "freesound.org"
-    * "raw_bubblingdrink.ogg" <https://freesound.org/people/swordofkings128/sounds/398029/>
+    * "raw_bubblingdrink.ogg"
+      https://freesound.org/people/swordofkings128/sounds/398029/
 
 4.1.3) CC BY-SA 3.0
 ====== ============
 * Lorenzo Sutton ("lorenzosu" at "freesound.org"):
-    * helicopterRaw_16sec.wav <https://archive.org/details/helicopterRaw_16sec>
+    * helicopterRaw_16sec.wav
+      https://archive.org/details/helicopterRaw_16sec
 
 4.2) Sound editors
 ==== =============

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,2 +1,2 @@
 ##grflangid 0x01
-STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of the following licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. Contains samples from "freesound.org" and "pdsounds.org". For full credits see "readme.txt". [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. For full credits see "readme.txt". [{TITLE}]

--- a/lang/english_US.lng
+++ b/lang/english_US.lng
@@ -1,3 +1,3 @@
 ##grflangid 0x00
 ##plural 0
-STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of the following licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. Contains samples from "freesound.org" and "pdsounds.org". For full credits see "readme.txt". [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. For full credits see "readme.txt". [{TITLE}]

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -1,4 +1,4 @@
 ##grflangid 0x02
 ##plural 0
 ##gender p m w n
-STR_GENERAL_DESC        :OpenSFX-Basissounds für OpenTTD. Frei verfügbar unter den folgenden Lizenzen: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License Version 2 (oder später) und Common Development and Distribution License 1.1. Es enthält Samples von freesound.org und pdsounds.org. Vollständige Referenzen sind in readme.txt zu finden. [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX-Basissounds für OpenTTD. Frei verfügbar unter diesen Lizenzen: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License Version 2 (oder später) und Common Development and Distribution License 1.1. Vollständige Referenzen sind in „readme.txt“ zu finden. [{TITLE}]


### PR DESCRIPTION
This is a simple PR for a few minor cleanup work in the text files, mainly about overlong lines.

This PR dos the following:

1) It shortens the main OpenSFX description a bit because it's quite long (it mentions 3 license names in full).
2) It shortens the lines in the license.txt and changelog.txt to avoid ugly overlong lines in the OpenTTD window.

The overlong lines in the readme.txt are NOT touched by this since they can't be really avoided (long URLs).