### PR TITLE
Shorten package description

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,2 +1,2 @@
 ##grflangid 0x01
-STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. For full credits see "readme.txt". [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licences: CC BY-SA 3.0, GPLv2 (or later) and CDDL 1.1. For full credits see "readme.txt". [{TITLE}]

--- a/lang/english_US.lng
+++ b/lang/english_US.lng
@@ -1,3 +1,3 @@
 ##grflangid 0x00
 ##plural 0
-STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licenses: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License version 2 (or later) and Common Development and Distribution License 1.1. For full credits see "readme.txt". [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licenses: CC BY-SA 3.0, GPLv2 (or later) and CDDL 1.1. For full credits see "readme.txt". [{TITLE}]

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -1,4 +1,4 @@
 ##grflangid 0x02
 ##plural 0
 ##gender p m w n
-STR_GENERAL_DESC        :OpenSFX-Basissounds für OpenTTD. Frei verfügbar unter diesen Lizenzen: Creative Commons Attribution-ShareAlike 3.0 Unported, GNU General Public License Version 2 (oder später) und Common Development and Distribution License 1.1. Vollständige Referenzen sind in „readme.txt“ zu finden. [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX-Basissounds für OpenTTD. Frei verfügbar unter diesen Lizenzen: CC BY-SA 3.0, GPLv2 (oder später) und CDDL 1.1. Vollständige Referenzen sind in „readme.txt“ zu finden. [{TITLE}]


### PR DESCRIPTION
Fixes #23.

The license names in the description are shortened.