### PR TITLE
Cleanup: Add -f to rm commands of make clean

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -45,6 +45,6 @@ endif
 sound: $(OBS_FILE)
 
 clean::
-	$(_V) -rm $(OBS_FILE)
-	$(_V) -rm $(SOUND_FILE)
-	$(_V) -rm src/$(SOUND_FILE)
+	$(_V) -rm -f $(OBS_FILE)
+	$(_V) -rm -f $(SOUND_FILE)
+	$(_V) -rm -f src/$(SOUND_FILE)


### PR DESCRIPTION
When you run `make clean` but the repo is already clean, you get a warning message from the `rm` command (file not found error).

This PR adds the `-f` parameter to suppress this warning.