### PR TITLE
 Add: Polish (pl_PL) and Finnish (fi_FI) translations

### DIFF
--- a/lang/finnish.lng
+++ b/lang/finnish.lng
@@ -1,0 +1,2 @@
+##grflangid 35x
+STR_GENERAL_DESC        :OpenSFX-äänenvaihtosarja OpenTTD: lle. Vapaasti saatavana näiden lisenssien ehtojen mukaisesti: CC BY-SA 3.0, GPLv2 (tai uudempi) ja CDDL 1.1. Katso täydet alkutekstit kohdasta "readme.txt". [{TITLE}]

--- a/lang/polish.lng
+++ b/lang/polish.lng
@@ -1,0 +1,5 @@
+##grflangid 0x30
+##plural 7
+##gender m f n
+##cases d c b n m w
+STR_GENERAL_DESC        :Zestaw zastępujący dźwięk OpenSFX dla OpenTTD. Dostępne swobodnie na warunkach tych licencji: CC BY-SA 3.0, GPLv2 (lub nowsza) i CDDL 1.1. Pełne napisy znajdziesz w „readme.txt”. [{TITLE}]


### PR DESCRIPTION
for OpenTTD/OpenSFX#27 two more translations added and text verified with another persons.

note - Finnish language matrix of cases and plurals is way more complex, and gender is mainly neutral.
For that reasons [NML specs for Language_files](https://newgrf-specs.tt-wiki.net/wiki/NML:Language_files) keep row of Finnish empty and hence they are not present in .lng file intentionally.