### PR TITLE
Fix: Specify AWS_DEFAULT_REGION in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
     - if: steps.vars.outputs.dry-run == 'false' && steps.vars.outputs.skip == 'false'
       name: Trigger 'update CDN'


### PR DESCRIPTION
Publishing the last nightly build failed - I assume this change is necessary since it was made in the OpenTTD and workflows repositories too.