### PR TITLE
Change: Stop calling OpenSFX a 'replacement'

### DIFF
--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -1,5 +1,5 @@
 OpenSFX README
-Last updated:    2021-03-12
+Last updated:    2021-03-17
 Release version: {{GRF_TITLE}}
 ------------------------------------------------------------------------
 
@@ -25,11 +25,9 @@ Table of Contents:
 OpenSFX is a set of base sounds for OpenTTD and is the result of the
 "Sound Effects Replacement" project.
 
-OpenSFX is a replacement for the original Transport Tycoon Deluxe
-base sounds used by OpenTTD. The main goal of OpenSFX therefore
-is to provide a set of free sounds which make it possible to play
-OpenTTD without requiring the (copyrighted) files from the Transport
-Tycoon Deluxe CD.
+The main goal of OpenSFX is to provide a set of free sounds which
+make it possible to play OpenTTD without requiring the (copyrighted) files
+from the Transport Tycoon Deluxe CD.
 
 The OpenSFX sounds are free as in 'free beer' and free
 as in 'freedom'.

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,2 +1,2 @@
 ##grflangid 0x01
-STR_GENERAL_DESC        :OpenSFX sound replacement set for OpenTTD. Freely available under the terms of these licences: CC BY-SA 3.0, GPLv2 (or later) and CDDL 1.1. For full credits see "readme.txt". [{TITLE}]
+STR_GENERAL_DESC        :OpenSFX base sound set for OpenTTD. Freely available under the terms of these licences: CC BY-SA 3.0, GPLv2 (or later) and CDDL 1.1. For full credits see "readme.txt". [{TITLE}]


### PR DESCRIPTION
Someone complained in IRC that OpenSFX/OpenMSX is called a 'replacement' which is severely underselling this base set. And I agree, it should not be called a 'replacement', it is perfectly valid in its own right.

This PR will change the description and README. Note the description file is changed again, which means the translations have to be reset (again). :-( Feel free to reject if you don't want to reset the translations.