### PR TITLE
Change: [Actions] Change nightly build time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     tags:
     - '*'
   schedule:
-  - cron: '15 21 * * *'
+  - cron: '0 22 * * *'
 
 jobs:
   publish_binaries:


### PR DESCRIPTION
Because of the way GitHub schedules workflows, the drift could still collide with other projects being build.

The website can only be build once every 3 minutes, but luck had it that OpenSFX / OpenMSX / OpenGFX managed to find the same moment to try this, despite them starting 15 minutes apart (and not taking 15 minutes to compile).

The drift in GitHub scheduler is just annoying.