### PR TITLE
Fix some licensing unclarities

### DIFF
--- a/docs/license.txt
+++ b/docs/license.txt
@@ -1,8 +1,9 @@
 ------------------------------------------------------------------------
 OVERVIEW
 ------------------------------------------------------------------------
-This is the OpenSFX license file. To see how these licenses apply to
-OpenSFX, see the readme file.
+This is the OpenSFX license file. It contains the licenses for OpenSFX
+as a whole. To see how these licenses apply to OpenSFX, see the readme
+file.
 
 The full license texts that apply to OpenSFX are given below:
 

--- a/docs/readme.ptxt
+++ b/docs/readme.ptxt
@@ -37,7 +37,7 @@ as in 'freedom'.
 OpenSFX is free software, you are allowed to freely use, copy, modify and
 share this, even commercially, as long you follow the licenses.
 
-The OpenSFX sounds are licensed under the
+The OpenSFX sound collection as a whole is licensed under the
     Creative Commons Attribution-ShareAlike 3.0 Unported
 license.
 
@@ -48,6 +48,18 @@ and
     Common Development and Distribution License 1.1.
 
 You can find the full license texts in license.txt.
+
+Note about individual sound files:
+
+Each individual sound file in OpenSFX is additionally
+released under another license, which is either the same as
+the overall license or a more permissive one.
+See "src/opensfx.psfo" in the source repository to see
+which license it is.
+So if you want to use a specific sound file from OpenSFX, you
+are free to choose whether the overall sound license
+mentioned above applies to you, or the license of the specific
+sound file.
 
 2.0) Installing
 ==== ==========
@@ -163,13 +175,14 @@ source sounds have been released under libre licenses like CC BY 3.0,
 allowing sharing and remixing.
 
 To see detailed license info about the actual sound files in OpenSFX,
-see "src/opensfx.sfo" in the source repository.
+see "src/opensfx.psfo" in the source repository.
 
 4.1) Sound credits of source sounds
 ==== ==============================
 This section gives credit to the original sound authors, i.e. the
-sounds before they were edited. All sounds are sorted by their license
-or legal status.
+sounds before they were edited. All sounds are sorted by their
+ORIGINAL license or legal status. This does not change
+the overall OpenSFX license.
 The name of the author, the origin website, the original file name
 and the URL (if available) are given, in this order.
 
@@ -390,7 +403,7 @@ Editing/(re)mixing was done by:
 * "Wuzzy" from "tt-forums.net"
 
 A detailed list of who has worked on what sample is available in the
-file "src/opensfx.sfo" in the source repository.
+file "src/opensfx.psfo" in the source repository.
 
 4.3) Other authors
 ==== =============

--- a/src/opensfx.psfo
+++ b/src/opensfx.psfo
@@ -41,8 +41,8 @@
 "src/wav/osfx_39.wav" "Building bridge". Original "in the smithy 2.wav" by "l0calh05t". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_40.wav" "Sawmill". Original "Circular saw crosscutting.wav" by "Benboncan". Edited by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_41.wav" "Toyland: Sugar mine (1)". Original "shaker2.wav" by "marvman". Cut and edited by "Wuzzy". License: Creative Commons Zero 1.0.
-"src/wav/osfx_42.wav" "Toyland: Toy factory (1)". Original "ae_51_m.wav" by "Sedi", "vial-glass-square-cinnamon-sticks-open-02.wav" by Jan Schupke aka "Vehicle" and "whoosh06.wav" by Richard Frohlich aka "FreqMan". Edited by "Wuzzy". License: Creative Commons Attribution 3.0.
-"src/wav/osfx_43.wav" "Toyland: Toy factory (2)". Original "ae_51_m.wav" by "Sedi" and "Slide Whistle, Descending, B (H1).wav" by "InspectorJ". Edited and mixed by "Wuzzy". License: Creative Commons Attribution 3.0.
+"src/wav/osfx_42.wav" "Toyland: Toy factory (1)". Original "ae_51_m.wav" by "Sedi", "vial-glass-square-cinnamon-sticks-open-02.wav" by Jan Schupke ("Vehicle"), "whoosh06.wav" by Richard Frohlich ("FreqMan"). Edit by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
+"src/wav/osfx_43.wav" "Toyland: Toy factory (2)". Original "ae_51_m.wav" by "Sedi" and "Slide Whistle, Descending, B (H1).wav" by "InspectorJ". Edited and mixed by "Wuzzy". License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_44.wav" "Toyland: Toy factory (3)". Orignal "nnb04_maxed.wav" by "Pooleside". Edited by Richard Wheeler. License: Creative Commons Attribution 3.0 Unported.
 "src/wav/osfx_45.wav" "Toyland: Sugar mine (2)". Original "shaker2.wav" by "marvman". Cut and edited by "Wuzzy". License: Creative Commons Zero 1.0.
 "src/wav/osfx_46.wav" "Toyland: Bubble generated". "Bubble 001.wav" by "ristooooo1". Edited by "Wuzzy". License: Creative Commons Zero 1.0.


### PR DESCRIPTION
This PR fixes some of the complaints from #46.

Changes:

* Fix file name mention of `opensfx.sfo` (should be `opensfx.psfo`)
* Fix missing "Unported" in `opensfx.psfo` (I checked this, it really is Unported)
* Explain that the individual sound licenses are optional, i.e. that you can choose whether to use the overall OpenSFX sound license or the license of the sound in the list