### PR TITLE
Fix: Remove generated .sfo file on clean

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -9,6 +9,7 @@ GENERATE_GRF       := sound
 BASE_FILENAME      := opensfx
 SOUND_FILE         := $(BASE_FILENAME).cat
 OBS_FILE           := $(BASE_FILENAME).obs
+SFO_FILE           := $(BASE_FILENAME).sfo
 
 SOUND_FILES        := $(ls src/wav/*.wav)
 LANG_FILES         := $(ls lang/*.lng)

--- a/Makefile.in
+++ b/Makefile.in
@@ -52,3 +52,4 @@ clean::
 	$(_V) -rm -f $(OBS_FILE)
 	$(_V) -rm -f $(SOUND_FILE)
 	$(_V) -rm -f src/$(SOUND_FILE)
+	$(_V) -rm -f src/$(SFO_FILE)


### PR DESCRIPTION
This fixes a part of #47.