### PR TITLE
Fix: Make uses `wildcard` to glob files, not `ls`.

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -10,8 +10,8 @@ BASE_FILENAME      := opensfx
 SOUND_FILE         := $(BASE_FILENAME).cat
 OBS_FILE           := $(BASE_FILENAME).obs
 
-SOUND_FILES        := $(ls src/wav/*.wav)
-LANG_FILES         := $(ls lang/*.lng)
+SOUND_FILES        := $(wildcard src/wav/*.wav)
+LANG_FILES         := $(wildcard lang/*.lng)
 
 BUNDLE_FILES        = $(BASE_FILENAME).obs $(DOC_FILES) $(SOUND_FILE)
 


### PR DESCRIPTION
Not sure what `ls` is meant to do but on my system it returns nothing. Use Make's `wildcard` built-in instead.

(This might just be a GNU Make extension, not sure...)